### PR TITLE
Fix issue with agent name parameter

### DIFF
--- a/rfswarm_agent/rfswarm_agent.py
+++ b/rfswarm_agent/rfswarm_agent.py
@@ -114,7 +114,6 @@ class RFSwarmAgent():
 
 		self.debugmsg(0, "	Configuration File: ", self.agentini)
 
-		self.agentname = socket.gethostname()
 		if self.args.agentname:
 			self.agentname = self.args.agentname
 
@@ -124,9 +123,10 @@ class RFSwarmAgent():
 			self.saveini()
 
 		if 'agentname' not in self.config['Agent']:
-			self.config['Agent']['agentname'] = self.agentname
+			self.config['Agent']['agentname'] = socket.gethostname()
 			self.saveini()
-		else:
+
+		if not self.args.agentname:
 			self.agentname = self.config['Agent']['agentname']
 
 		if 'agentdir' not in self.config['Agent']:


### PR DESCRIPTION
Currently the -a or --agentname option for rfswarm-agent is not updating the actual agent name in the manager. This PR addresses that issue.

If agent name is now passed as a parameter it will override the value in the .ini file. If there is no parameter passed the value will be read from the .ini file. If the value doesn't exist in the .ini file already, the agent machine hostname is first written to the .ini file.