### PR TITLE
Fix issue with agentname parameter #100

### DIFF
--- a/Doc/rfswarm_py.md
+++ b/Doc/rfswarm_py.md
@@ -204,7 +204,7 @@ This is where you can see which agents have connected, number of robots on each 
 The columns for the agents screen
 | Column Name	| Detail |
 |---		|---	|
-| Status	| This is the last status reported by the agent, unless a agent hasn't reported for a while, then this will show "Offline?" |
+| Status	| This is the last status reported by the agent, unless a agent hasn't reported for a while, then this will show "Offline?". If the agent load is over 80% then status will be "Warning", and over 95% "Critical". All other status values are reported by the agent. |
 | Agent		| This is the agent's name as reported by the agent, usually this is the agent's host name but this can be configured on the agent |
 | Last Seen	| This is the time the last status update was received from the agent |
 | Assigned	| This is the number of robots assigned to the agent during ramp up |

--- a/rfswarm_agent/rfswarm_agent.py
+++ b/rfswarm_agent/rfswarm_agent.py
@@ -114,7 +114,6 @@ class RFSwarmAgent():
 
 		self.debugmsg(0, "	Configuration File: ", self.agentini)
 
-		self.agentname = socket.gethostname()
 		if self.args.agentname:
 			self.agentname = self.args.agentname
 
@@ -124,9 +123,10 @@ class RFSwarmAgent():
 			self.saveini()
 
 		if 'agentname' not in self.config['Agent']:
-			self.config['Agent']['agentname'] = self.agentname
+			self.config['Agent']['agentname'] = socket.gethostname()
 			self.saveini()
-		else:
+
+		if not self.args.agentname:
 			self.agentname = self.config['Agent']['agentname']
 
 		if 'agentdir' not in self.config['Agent']:


### PR DESCRIPTION
Fix issue https://github.com/damies13/rfswarm/issues/100 where the -a or --agentname CLI option for rfswarm-agent is not updating the actual agent name shown in the manager.

See the original pull request for more reference: https://github.com/damies13/rfswarm/pull/99