### PR TITLE
Bug fix for Issue #288 - Console outputs from Manager/Agent/Reporter cannot be saved to the file/variable/etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ Tests/**/Logs/**/Sikuli_java_*.txt
 !Tests/**/*.html
 !Tests/**/testdata/**/*
 Tests/**/testdata/**/.DS_Store
+Tests/**/*.pyc
+Tests/**/__pycache__

--- a/Tests/Regression/Manager/GUI_Common.robot
+++ b/Tests/Regression/Manager/GUI_Common.robot
@@ -155,13 +155,12 @@ Close Manager GUI macos
 	END
 
 Stop Agent
-	${result} = 	Terminate Process		${process_agent}
-	# IF  '${platform}' == 'windows'
-	# 	Evaluate	os.kill(${process_agent.pid}, signal.SIGINT)	modules=subprocess, os, signal
-	# ELSE
-	# 	Send Signal To Process 	SIGINT 	${process_agent}
-	# END
-	${result}= 	Wait For Process 	${process_agent}	timeout=30	on_timeout=kill
+	IF  '${platform}' == 'windows'	# Send Signal To Process keyword does not work on Windows
+		${result} = 	Terminate Process		${process_agent}
+	ELSE
+		Send Signal To Process 	SIGINT 	${process_agent}
+		${result}= 	Wait For Process 	${process_agent}	timeout=30	on_timeout=kill
+	END
 	Log		${result.stdout}
 	Log		${result.stderr}
 	# Should Be Equal As Integers 	${result.rc} 	0

--- a/Tests/Regression/Manager/GUI_Common.robot
+++ b/Tests/Regression/Manager/GUI_Common.robot
@@ -155,9 +155,13 @@ Close Manager GUI macos
 	END
 
 Stop Agent
-	# ${result} = 	Terminate Process		${process_agent}
-	Send Signal To Process 	SIGINT 	${process_agent}
-	${result}= 	Wait For Process 	${process_agent}
+	${result} = 	Terminate Process		${process_agent}
+	# IF  '${platform}' == 'windows'
+	# 	Evaluate	os.kill(${process_agent.pid}, signal.SIGINT)	modules=subprocess, os, signal
+	# ELSE
+	# 	Send Signal To Process 	SIGINT 	${process_agent}
+	# END
+	${result}= 	Wait For Process 	${process_agent}	timeout=30	on_timeout=kill
 	Log		${result.stdout}
 	Log		${result.stderr}
 	# Should Be Equal As Integers 	${result.rc} 	0

--- a/Tests/Regression/Manager/GUI_Common.robot
+++ b/Tests/Regression/Manager/GUI_Common.robot
@@ -155,7 +155,9 @@ Close Manager GUI macos
 	END
 
 Stop Agent
-	${result} = 	Terminate Process		${process_agent}
+	# ${result} = 	Terminate Process		${process_agent}
+	Send Signal To Process 	SIGINT 	${process_agent}
+	${result}= 	Wait For Process 	${process_agent}
 	Log		${result.stdout}
 	Log		${result.stderr}
 	# Should Be Equal As Integers 	${result.rc} 	0

--- a/Tests/Regression/Reporter/GUI_Common.robot
+++ b/Tests/Regression/Reporter/GUI_Common.robot
@@ -298,6 +298,8 @@ Close GUI
 
 Check Result
 	[Arguments]		${result}
+	Log 	${result.stdout}
+	Should Not Contain 	${result.stdout} 	Traceback
 	Log 	${result.stderr}
 	Should Not Contain 	${result.stderr} 	Traceback
 	Should Be Equal As Integers 	${result.rc} 	0

--- a/rfswarm_agent/rfswarm_agent.py
+++ b/rfswarm_agent/rfswarm_agent.py
@@ -1975,16 +1975,6 @@ class RFSwarmAgent():
 			self.jobs[jobid]["Thread"].join()
 
 		time.sleep(1)
-		self.debugmsg(3, "Waiting for all threads to be completed")
-		for thread in threading.enumerate():
-			if thread is not threading.main_thread() and thread.is_alive():
-				if thread.name not in ["UpdateAgents"]:
-					self.debugmsg(9, thread.name, "before")
-					thread.join(timeout=30)
-					self.debugmsg(9, thread.name, "after")
-					if thread.is_alive():
-						self.debugmsg(9, thread.name, "did not complete in 30s!")
-
 		self.debugmsg(2, "Exit")
 		try:
 			sys.exit(0)
@@ -1992,7 +1982,7 @@ class RFSwarmAgent():
 			try:
 				remaining_threads = [t for t in threading.enumerate() if t is not threading.main_thread() and t.is_alive()]
 				if remaining_threads:
-					self.debugmsg(3, "Failed to gracefully exit RFSwarm-Agent. Forcing immediate exit.")
+					self.debugmsg(5, "Failed to gracefully exit RFSwarm-Agent. Forcing immediate exit.")
 					for thread in remaining_threads:
 						self.debugmsg(9, "Thread name:", thread.name)
 					os._exit(0)

--- a/rfswarm_manager/rfswarm.py
+++ b/rfswarm_manager/rfswarm.py
@@ -2705,7 +2705,7 @@ class RFSwarmCore:
 			if thread.name != "MainThread":
 				if thread.is_alive():
 					base.debugmsg(9, thread.name, "before")
-					thread.join(timeout=30)
+					thread.join(timeout=60)
 					base.debugmsg(9, thread.name, "after")
 
 		try:

--- a/rfswarm_manager/rfswarm.py
+++ b/rfswarm_manager/rfswarm.py
@@ -2702,7 +2702,7 @@ class RFSwarmCore:
 		time.sleep(1)
 		base.debugmsg(2, "Exit")
 		for thread in threading.enumerate():
-			if thread.name != "MainThread":
+			if thread.name not in ['MainLoop', 'UpdateAgents']:
 				if thread.is_alive():
 					base.debugmsg(9, thread.name, "before")
 					thread.join(timeout=60)

--- a/rfswarm_manager/rfswarm.py
+++ b/rfswarm_manager/rfswarm.py
@@ -2662,14 +2662,6 @@ class RFSwarmCore:
 		base.keeprunning = False
 		self.neededagents = 0
 
-		try:
-			if base.updateplanthread.is_alive():
-				base.debugmsg(9, "Join Update Plan Display")
-				base.updateplanthread.join(timeout=30)
-				base.debugmsg(9, "Join Update Plan Display after")
-		except Exception:
-			pass
-
 		if base.appstarted:
 			try:
 				base.debugmsg(0, "Shutdown Agent Manager")
@@ -2702,16 +2694,6 @@ class RFSwarmCore:
 			pass
 
 		time.sleep(1)
-		base.debugmsg(3, "Waiting for all threads to be completed")
-		for thread in threading.enumerate():
-			if thread is not threading.main_thread() and thread.is_alive():
-				if thread.name not in ["UpdateAgents"]:
-					base.debugmsg(9, thread.name, "before")
-					thread.join(timeout=30)
-					base.debugmsg(9, thread.name, "after")
-					if thread.is_alive():
-						base.debugmsg(9, thread.name, "did not complete in 30s!")
-
 		base.debugmsg(2, "Exit")
 		try:
 			sys.exit(0)
@@ -2719,7 +2701,7 @@ class RFSwarmCore:
 			try:
 				remaining_threads = [t for t in threading.enumerate() if t is not threading.main_thread() and t.is_alive()]
 				if remaining_threads:
-					base.debugmsg(3, "Failed to gracefully exit RFSwarm-Manager. Forcing immediate exit.")
+					base.debugmsg(5, "Failed to gracefully exit RFSwarm-Manager. Forcing immediate exit.")
 					for thread in remaining_threads:
 						base.debugmsg(9, "Thread name:", thread.name)
 					os._exit(0)

--- a/rfswarm_manager/rfswarm.py
+++ b/rfswarm_manager/rfswarm.py
@@ -45,7 +45,6 @@ from typing import Any
 
 import matplotlib  # required for matplot graphs
 import psutil
-import requests
 
 # required for matplot graphs
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
@@ -5372,7 +5371,7 @@ class RFSwarmGUI(tk.Frame):
 		# self.pln_graph.bind("<Configure>", self.CanvasResize)
 		# May need to bind <Button-4> and <Button-5> to enable mouse scrolling
 		# https://www.python-course.eu/tkinter_events_binds.php
-		
+
 		base.updateplanthread = threading.Thread(target=self.UpdatePlanDisplay)
 		base.updateplanthread.start()
 

--- a/rfswarm_reporter/rfswarm_reporter.py
+++ b/rfswarm_reporter/rfswarm_reporter.py
@@ -2869,13 +2869,21 @@ class ReporterCore:
 		base.stop_db()
 
 		base.debugmsg(2, "Exit")
+		for thread in threading.enumerate():
+			if thread.name != "MainThread":
+				if thread.is_alive():
+					base.debugmsg(9, thread.name, "before")
+					thread.join(timeout=30)
+					base.debugmsg(9, thread.name, "after")
+
 		try:
 			sys.exit(0)
-		except SystemExit:
+		except Exception as e:
 			try:
-				os._exit(0)
+				self.debugmsg(0, "Failed to exit with error:", e)
+				sys.exit(0)
 			except Exception:
-				pass
+				os._exit(0)
 
 	def selectResults(self, resultsfile):
 		base.debugmsg(5, "resultsfile:", resultsfile)
@@ -6490,6 +6498,7 @@ class ReporterGUI(tk.Frame):
 		# self.sectionstree.see(sectionID)
 
 	def on_closing(self, _event=None, *extras):
+		base.running = False
 		try:
 			base.debugmsg(5, "close window")
 			self.destroy()

--- a/setup-manager.py
+++ b/setup-manager.py
@@ -16,7 +16,7 @@ setuptools.setup(
 	# I needed a recent version of pip (pip 21.0.1 worked my previous <20 version didn't) for matplotlib
 	# 	to actually install withput error
 	# https://matplotlib.org/stable/users/installing.html
-	install_requires=['configparser', 'HTTPServer', 'pillow>=9.1.0', 'psutil', 'pip>=21,>=22', 'matplotlib', 'requests'],
+	install_requires=['configparser', 'HTTPServer', 'pillow>=9.1.0', 'psutil', 'pip>=21,>=22', 'matplotlib'],
 	classifiers=[
 		"Development Status :: 5 - Production/Stable",
 		"Framework :: Robot Framework",


### PR DESCRIPTION
Managed to get output saved from Manager, Agent and Reporter in almost every situation. Sometimes some threads updating Tkinter items get frozen because the program is closed before the thread updates its fields etc. **It's quite rare but still possible**. 
So, in these scenarios RFSwarm apps will perform an immediate exit as before and output will not be saved. The closing times will be exactly the same.
All critical threads for RFSwarm apps will finish their jobs as before so nothing should break.

We should reconsider joining all currently running threads after the potential implementation of the eel module in v2.0.0 which, which will give us saved outputs under all conditions.

Issue #288