### PR TITLE
Issue #320 - Print information in cmd that the rfswarm application icon / shortcut is not installed

### DIFF
--- a/.github/workflows/Main.yaml
+++ b/.github/workflows/Main.yaml
@@ -44,6 +44,8 @@ jobs:
     - Regression_Tests_Agent
     - Regression_Tests_Manager
     - Regression_Tests_Reporter
+    permissions:
+      id-token: write
     uses: ./.github/workflows/Publish.yaml
     secrets: inherit
 

--- a/rfswarm_agent/rfswarm_agent.py
+++ b/rfswarm_agent/rfswarm_agent.py
@@ -209,6 +209,9 @@ class RFSwarmAgent():
 			self.config['Agent']['properties'] = ""
 			self.saveini()
 
+		if not self.args.create:
+			self.check_icons("RFSwarm Agent")
+
 		self.findlibraries() 	# Need to wait for findlibraries() to finish before calling ensure_listner_file() for RF version check
 		self.ensure_listner_file()
 		self.ensure_repeater_listner_file()
@@ -319,12 +322,12 @@ class RFSwarmAgent():
 			desktopdata.append('Keywords=rfswarm;agent;\n')
 			# desktopdata.append('\n')
 
-			dektopfilename = os.path.join(fileprefix, "applications", projname + ".desktop")
-			dektopdir = os.path.dirname(dektopfilename)
-			self.ensuredir(dektopdir)
+			desktopfilename = os.path.join(fileprefix, "applications", projname + ".desktop")
+			desktopdir = os.path.dirname(desktopfilename)
+			self.ensuredir(desktopdir)
 
-			self.debugmsg(5, "dektopfilename:", dektopfilename)
-			with open(dektopfilename, 'w') as df:
+			self.debugmsg(5, "desktopfilename:", desktopfilename)
+			with open(desktopfilename, 'w') as df:
 				df.writelines(desktopdata)
 
 			self.debugmsg(5, "Copy icons")
@@ -506,6 +509,35 @@ class RFSwarmAgent():
 		# self.debugmsg(6, "cmd:", cmd)
 		# response = os.popen(cmd).read()
 		# self.debugmsg(6, "response:", response)
+
+	def check_icons(self, appname):
+		projname = "-".join(appname.split()).lower()
+		if platform.system() == 'Linux':
+			fileprefix = "~/.local/share"
+			if os.access("/usr/share", os.W_OK):
+				fileprefix = "/usr/share"
+			fileprefix = os.path.expanduser(fileprefix)
+			desktopfilename = os.path.join(fileprefix, "applications", projname + ".desktop")
+			if not os.path.exists(desktopfilename):
+				self.debugmsg(1, f"{appname} icon / shortcut is not installed. You can create it using the -c or --create flags.")
+
+		elif platform.system() == 'Darwin':
+			appspath = "~/Applications"
+			if os.access("/Applications", os.W_OK):
+				appspath = "/Applications"
+			appspath = os.path.expanduser(appspath)
+			apppath = os.path.join(appspath, appname + ".app")
+			ResourcesFolder = os.path.join(apppath, "Contents", "Resources")
+			iconset = os.path.join(ResourcesFolder, projname + ".iconset")
+			if not os.path.exists(iconset):
+				self.debugmsg(1, f"{appname} icon / shortcut is not installed. You can create it using the -c or --create flags.")
+
+		elif platform.system() == 'Windows':
+			roam_appdata = os.environ["APPDATA"]
+			scutpath = os.path.join(roam_appdata, "Microsoft", "Windows", "Start Menu", appname + ".lnk")
+			# directorydir = os.path.dirname(scutpath)
+			if not os.path.exists(scutpath):
+				self.debugmsg(1, f"{appname} icon / shortcut is not installed. You can create it using the -c or --create flags.")
 
 	def findiniloctaion(self):
 

--- a/rfswarm_manager/rfswarm.py
+++ b/rfswarm_manager/rfswarm.py
@@ -660,6 +660,9 @@ class RFSwarmCore:
 		# 	end ensure ini file
 		#
 
+		if not base.args.create and not base.args.nogui:
+			self.check_icons("RFSwarm Manager")
+
 		if base.args.nogui:
 			base.save_ini = False
 			if not base.args.run:
@@ -898,12 +901,12 @@ class RFSwarmCore:
 			desktopdata.append('Keywords=rfswarm;manager;\n')
 			# desktopdata.append('\n')
 
-			dektopfilename = os.path.join(fileprefix, "applications", projname + ".desktop")
-			dektopdir = os.path.dirname(dektopfilename)
-			base.ensuredir(dektopdir)
+			desktopfilename = os.path.join(fileprefix, "applications", projname + ".desktop")
+			desktopdir = os.path.dirname(desktopfilename)
+			base.ensuredir(desktopdir)
 
-			base.debugmsg(5, "dektopfilename:", dektopfilename)
-			with open(dektopfilename, 'w') as df:
+			base.debugmsg(5, "desktopfilename:", desktopfilename)
+			with open(desktopfilename, 'w') as df:
 				df.writelines(desktopdata)
 
 			base.debugmsg(5, "Copy icons")
@@ -1089,6 +1092,35 @@ class RFSwarmCore:
 		# base.debugmsg(6, "cmd:", cmd)
 		# response = os.popen(cmd).read()
 		# base.debugmsg(6, "response:", response)
+
+	def check_icons(self, appname):
+		projname = "-".join(appname.split()).lower()
+		if platform.system() == 'Linux':
+			fileprefix = "~/.local/share"
+			if os.access("/usr/share", os.W_OK):
+				fileprefix = "/usr/share"
+			fileprefix = os.path.expanduser(fileprefix)
+			desktopfilename = os.path.join(fileprefix, "applications", projname + ".desktop")
+			if not os.path.exists(desktopfilename):
+				base.debugmsg(1, f"{appname} icon / shortcut is not installed. You can create it using the -c or --create flags.")
+
+		elif platform.system() == 'Darwin':
+			appspath = "~/Applications"
+			if os.access("/Applications", os.W_OK):
+				appspath = "/Applications"
+			appspath = os.path.expanduser(appspath)
+			apppath = os.path.join(appspath, appname + ".app")
+			ResourcesFolder = os.path.join(apppath, "Contents", "Resources")
+			iconset = os.path.join(ResourcesFolder, projname + ".iconset")
+			if not os.path.exists(iconset):
+				base.debugmsg(1, f"{appname} icon / shortcut is not installed. You can create it using the -c or --create flags.")
+
+		elif platform.system() == 'Windows':
+			roam_appdata = os.environ["APPDATA"]
+			scutpath = os.path.join(roam_appdata, "Microsoft", "Windows", "Start Menu", appname + ".lnk")
+			# directorydir = os.path.dirname(scutpath)
+			if not os.path.exists(scutpath):
+				base.debugmsg(1, f"{appname} icon / shortcut is not installed. You can create it using the -c or --create flags.")
 
 	# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 	#

--- a/rfswarm_reporter/ReporterGUI.py
+++ b/rfswarm_reporter/ReporterGUI.py
@@ -4581,13 +4581,15 @@ class ReporterGUI(tk.Frame):
 		# if type(_event) is not type(""):
 		if not isinstance(_event, str):
 			# self.mnu_file_Close()	# ensure any previous scenario is closed and saved if required
-			ResultsFile = str(
-				tkf.askopenfilename(
-					initialdir=self.base.config['Reporter']['ResultDir'],
-					title="Select RFSwarm Results File",
-					filetypes=(("RFSwarm Results", "*.db"), ("all files", "*.*"))
-				)
+			filename = tkf.askopenfilename(
+				initialdir=self.base.config['Reporter']['ResultDir'],
+				title="Select RFSwarm Results File",
+				filetypes=(("RFSwarm Results", "*.db"), ("all files", "*.*"))
 			)
+			if filename:
+				ResultsFile = str(filename)
+			else:
+				ResultsFile = ""
 		else:
 			ResultsFile = _event
 

--- a/rfswarm_reporter/rfswarm_reporter.py
+++ b/rfswarm_reporter/rfswarm_reporter.py
@@ -223,6 +223,9 @@ class ReporterCore:
 				base.config['Reporter']['TemplateDir'] = ""
 				base.saveini()
 
+		if not base.args.create and not base.args.nogui:
+			self.check_icons("RFSwarm Reporter")
+
 		usetemplate = False
 		if base.args.template:
 			usetemplate = True
@@ -403,12 +406,12 @@ class ReporterCore:
 			desktopdata.append('Keywords=rfswarm;reporter;\n')
 			# desktopdata.append('\n')
 
-			dektopfilename = os.path.join(fileprefix, "applications", projname + ".desktop")
-			dektopdir = os.path.dirname(dektopfilename)
-			base.ensuredir(dektopdir)
+			desktopfilename = os.path.join(fileprefix, "applications", projname + ".desktop")
+			desktopdir = os.path.dirname(desktopfilename)
+			base.ensuredir(desktopdir)
 
-			base.debugmsg(5, "dektopfilename:", dektopfilename)
-			with open(dektopfilename, 'w') as df:
+			base.debugmsg(5, "desktopfilename:", desktopfilename)
+			with open(desktopfilename, 'w') as df:
 				df.writelines(desktopdata)
 
 			base.debugmsg(5, "Copy icons")
@@ -592,6 +595,35 @@ class ReporterCore:
 		# base.debugmsg(6, "cmd:", cmd)
 		# response = os.popen(cmd).read()
 		# base.debugmsg(6, "response:", response)
+
+	def check_icons(self, appname):
+		projname = "-".join(appname.split()).lower()
+		if platform.system() == 'Linux':
+			fileprefix = "~/.local/share"
+			if os.access("/usr/share", os.W_OK):
+				fileprefix = "/usr/share"
+			fileprefix = os.path.expanduser(fileprefix)
+			desktopfilename = os.path.join(fileprefix, "applications", projname + ".desktop")
+			if not os.path.exists(desktopfilename):
+				base.debugmsg(1, f"{appname} icon / shortcut is not installed. You can create it using the -c or --create flags.")
+
+		elif platform.system() == 'Darwin':
+			appspath = "~/Applications"
+			if os.access("/Applications", os.W_OK):
+				appspath = "/Applications"
+			appspath = os.path.expanduser(appspath)
+			apppath = os.path.join(appspath, appname + ".app")
+			ResourcesFolder = os.path.join(apppath, "Contents", "Resources")
+			iconset = os.path.join(ResourcesFolder, projname + ".iconset")
+			if not os.path.exists(iconset):
+				base.debugmsg(1, f"{appname} icon / shortcut is not installed. You can create it using the -c or --create flags.")
+
+		elif platform.system() == 'Windows':
+			roam_appdata = os.environ["APPDATA"]
+			scutpath = os.path.join(roam_appdata, "Microsoft", "Windows", "Start Menu", appname + ".lnk")
+			# directorydir = os.path.dirname(scutpath)
+			if not os.path.exists(scutpath):
+				base.debugmsg(1, f"{appname} icon / shortcut is not installed. You can create it using the -c or --create flags.")
 
 	def selectResults(self, resultsfile):
 		base.debugmsg(5, "resultsfile:", resultsfile)


### PR DESCRIPTION
Additionally, a minor fix was made for Reporter on linux for Issue #384.
Furthermore, it was required to add permission in Main.yaml for Publish.yaml beacause the GitHub actions failed due to an "Invalid workflow file" before execution.